### PR TITLE
Inject dependencies into Gutentag::Persistence

### DIFF
--- a/lib/gutentag/active_record.rb
+++ b/lib/gutentag/active_record.rb
@@ -10,7 +10,7 @@ module Gutentag::ActiveRecord
       has_many :tags,     :class_name => 'Gutentag::Tag',
         :through => :taggings
 
-      after_save Gutentag::Persistence
+      after_save { |instance| Gutentag::Persistence.new(instance).persist  }
     end
   end
 


### PR DESCRIPTION
@pat - given that it's whyday and all, thought I would try and hack on some ideas I got when I read your most excellent and informative `Gutentag` :smile: 

I wondered whether we could remove the dependencies of `Gutentag::Persistence` on `Gutentag::TagName` and `Gutentag::Tag` and inject these instead. Also, I didn't know why you have `after_save` be a class method and why it's calling initialize ... so I wondered whether this was necessary. 

So, this PR is the result of my playing around with these themes. I checked that this keeps the 4.0 score on code climate, and specs pass etc. 

Does this improve anything?(!) Would love your feedback ... 

Oh and thanks much for writing `Gutentag` - have learned so much from studying it. 
