### PR TITLE
Add support for ActiveModel dirty on tag_names change.

### DIFF
--- a/lib/gutentag/active_record.rb
+++ b/lib/gutentag/active_record.rb
@@ -23,6 +23,15 @@ module Gutentag::ActiveRecord
   end
 
   def tag_names=(names)
+    existing = _denormalised(tag_names) || []
+    new = _denormalised(names) || []
+    changes = (existing + new).uniq - (existing & new)
+    changed_attributes[:tag_names] = tag_names if changes.present?
     @tag_names = names
+  end
+
+  private
+  def _denormalised(names)
+    names.split(",").flatten rescue names
   end
 end

--- a/spec/acceptance/tag_names_spec.rb
+++ b/spec/acceptance/tag_names_spec.rb
@@ -18,6 +18,24 @@ describe "Managing tags via names" do
     article.tags.collect(&:name).should == ['melbourne']
   end
 
+  it "makes model dirty when changing through tag_names" do
+    article.tag_names << 'melbourne'
+    article.save!
+
+    article.tag_names = ['sydney']
+
+    article.changed_attributes.should == { :tag_names => ['melbourne'] }
+  end
+
+  it "does not make model dirty when changing through tag_names" do
+    article.tag_names << 'melbourne'
+    article.save!
+
+    article.tag_names = ['melbourne']
+
+    article.changed_attributes.should == {}
+  end
+
   it "allows for different tag normalisation" do
     Gutentag.normaliser = lambda { |name| name.upcase }
 


### PR DESCRIPTION
Write to changed_attributes on tag_names change so that `object.changed?`, `changed_attributes`, `changes`, etc reflect tag_names changes.
