### PR TITLE
Add in_tag class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Changes to tag_names are not persisted immediately - you must save your taggable
     article.tag_names << 'ruby'
     article.save
 
+### `Model.in_tag('tag1', 'tag2', ...)`
+
+    Article.in_tag('tag1', 'tag2')
+    Article.in_tag(:tag1, :tag2)
+    Article.in_tag(Gutentag::Tag.where(name: ['tag1', 'tag2'])
+    # => [#<Article id: "123">]
+
 ## Contribution
 
 Please note that this project now has a [Contributor Code of Conduct](http://contributor-covenant.org/version/1/0/0/). By participating in this project you agree to abide by its terms.

--- a/lib/gutentag/active_record.rb
+++ b/lib/gutentag/active_record.rb
@@ -15,7 +15,7 @@ module Gutentag::ActiveRecord
 
     def in_tag(*tags)
       names = tags.flatten.map { |tag| tag.respond_to?(:name) ? tag.name : tag.to_s }
-      joins(:tags).where(Gutentag::Tag.table_name => { name: names })
+      joins(:tags).where(Gutentag::Tag.table_name => { name: names }).uniq
     end
   end
 

--- a/lib/gutentag/active_record.rb
+++ b/lib/gutentag/active_record.rb
@@ -12,6 +12,11 @@ module Gutentag::ActiveRecord
 
       after_save :persist_tags
     end
+
+    def in_tag(*tags)
+      names = tags.flatten.map { |tag| tag.respond_to?(:name) ? tag.name : tag.to_s }
+      joins(:tags).where(Gutentag::Tag.table_name => { name: names })
+    end
   end
 
   def reset_tag_names

--- a/spec/gutentag/active_record_spec.rb
+++ b/spec/gutentag/active_record_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Gutentag::ActiveRecord do
+  describe '.in_tag' do
+    let!(:melborne_article) do
+      article = Article.create title: 'Overview'
+      article.tag_names << 'melborne'
+      article.save!
+      article
+    end
+
+    let!(:oregon_article) do
+      article = Article.create
+      article.tag_names << 'oregon'
+      article.save!
+      article
+    end
+
+    context 'given a single tag name' do
+      subject { Article.in_tag('melborne') }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.not_to include oregon_article }
+    end
+
+    context 'given a single tag name[symbol]' do
+      subject { Article.in_tag(:melborne) }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.not_to include oregon_article }
+    end
+
+    context 'given multiple tag names' do
+      subject { Article.in_tag('melborne', 'oregon') }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.to include oregon_article }
+    end
+
+    context 'given an array of tag names' do
+      subject { Article.in_tag(%w(melborne oregon)) }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.to include oregon_article }
+    end
+
+    context 'given a single tag instance' do
+      subject { Article.in_tag(Gutentag::Tag.find_by_name('melborne')) }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.not_to include oregon_article }
+    end
+
+    context 'given multiple tag objects' do
+      subject { Article.in_tag(Gutentag::Tag.where(name: %w(melborne oregon))) }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.to include oregon_article }
+    end
+
+    context 'chaining where clause' do
+      subject { Article.in_tag(%w(melborne oregon)).where(title: 'Overview') }
+
+      it { is_expected.to include melborne_article }
+      it { is_expected.not_to include oregon_article }
+    end
+  end
+end

--- a/spec/gutentag/active_record_spec.rb
+++ b/spec/gutentag/active_record_spec.rb
@@ -16,53 +16,64 @@ describe Gutentag::ActiveRecord do
       article
     end
 
+    let!(:melborne_oregon_article) do
+      article = Article.create
+      article.tag_names = %w(oregon melborne)
+      article.save!
+      article
+    end
+
     context 'given a single tag name' do
       subject { Article.in_tag('melborne') }
 
-      it { is_expected.to include melborne_article }
+      it { expect(subject.count).to eq 2 }
+      it { is_expected.to include melborne_article, melborne_oregon_article }
       it { is_expected.not_to include oregon_article }
     end
 
     context 'given a single tag name[symbol]' do
       subject { Article.in_tag(:melborne) }
 
-      it { is_expected.to include melborne_article }
+      it { expect(subject.count).to eq 2 }
+      it { is_expected.to include melborne_article, melborne_oregon_article }
       it { is_expected.not_to include oregon_article }
     end
 
     context 'given multiple tag names' do
       subject { Article.in_tag('melborne', 'oregon') }
 
-      it { is_expected.to include melborne_article }
-      it { is_expected.to include oregon_article }
+      it { expect(subject.count).to eq 3 }
+      it { is_expected.to include melborne_article, oregon_article, melborne_oregon_article }
     end
 
     context 'given an array of tag names' do
       subject { Article.in_tag(%w(melborne oregon)) }
 
-      it { is_expected.to include melborne_article }
-      it { is_expected.to include oregon_article }
+      it { expect(subject.count).to eq 3 }
+      it { is_expected.to include melborne_article, oregon_article, melborne_oregon_article }
     end
 
     context 'given a single tag instance' do
       subject { Article.in_tag(Gutentag::Tag.find_by_name('melborne')) }
 
-      it { is_expected.to include melborne_article }
+      it { expect(subject.count).to eq 2 }
+      it { is_expected.to include melborne_article, melborne_oregon_article }
       it { is_expected.not_to include oregon_article }
     end
 
     context 'given multiple tag objects' do
       subject { Article.in_tag(Gutentag::Tag.where(name: %w(melborne oregon))) }
 
-      it { is_expected.to include melborne_article }
-      it { is_expected.to include oregon_article }
+      it { expect(subject.count).to eq 3 }
+      it { is_expected.to include melborne_article, oregon_article, melborne_oregon_article }
     end
 
     context 'chaining where clause' do
       subject { Article.in_tag(%w(melborne oregon)).where(title: 'Overview') }
 
+      it { expect(subject.count).to eq 1 }
       it { is_expected.to include melborne_article }
-      it { is_expected.not_to include oregon_article }
+      it { is_expected.not_to include oregon_article, melborne_oregon_article }
     end
   end
 end


### PR DESCRIPTION
Hi, thank you for the simple tagging gem.

I'd like to add this method. How does that look?
```ruby
Article.in_tag('tag1', 'tag2')
Article.in_tag(:tag1, :tag2)
Article.in_tag(Gutentag::Tag.where(name: ['tag1', 'tag2'])
# => [#<Article id: "123">]
```