### PR TITLE
Default rake and rake test should run full test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,9 @@
 require 'bundler'
+require 'rspec/core/rake_task'
 
 Bundler::GemHelper.install_tasks
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: [:test]
+task test: [:spec]


### PR DESCRIPTION
Hi Pat

I expected that `rake` and  `rake test` should run the tests - in addition to `rspec spec`. 
If you agree then this is a pull request to do just that.

Rich