### PR TITLE
produce cheaper queries when only seaching for ids or tags

### DIFF
--- a/lib/gutentag/active_record.rb
+++ b/lib/gutentag/active_record.rb
@@ -16,9 +16,19 @@ module Gutentag::ActiveRecord
     end
 
     def tagged_with(*tags)
-      joins(:tags).where(
-        Gutentag::Tag.table_name => {:name => Gutentag::TagNames.call(tags)}
-      ).public_send UNIQUENESS_METHOD
+      tags.flatten!
+      scope =
+        if tags.all? { |t| t.is_a?(Integer) || t.is_a?(Gutentag::Tag) }
+          tag_ids = tags.map { |t| t.is_a?(Gutentag::Tag) ? t.id : t }
+          joins(:taggings).where(
+            Gutentag::Tagging.table_name => {:tag_id => tag_ids}
+          )
+        else
+          joins(:tags).where(
+            Gutentag::Tag.table_name => {:name => Gutentag::TagNames.call(tags)}
+          )
+        end
+      scope.public_send UNIQUENESS_METHOD
     end
   end
 

--- a/spec/gutentag/active_record_spec.rb
+++ b/spec/gutentag/active_record_spec.rb
@@ -54,11 +54,21 @@ describe Gutentag::ActiveRecord do
     end
 
     context 'given a single tag instance' do
-      subject { Article.tagged_with(Gutentag::Tag.find_by_name('melborne')) }
+      subject { Article.tagged_with(Gutentag::Tag.find_by_name!('melborne')) }
 
       it { expect(subject.count).to eq 2 }
       it { is_expected.to include melborne_article, melborne_oregon_article }
       it { is_expected.not_to include oregon_article }
+      it { expect(subject.to_sql).not_to include 'gutentag_tags' }
+    end
+
+    context 'given a single tag id' do
+      subject { Article.tagged_with(Gutentag::Tag.find_by_name!('melborne').id) }
+
+      it { expect(subject.count).to eq 2 }
+      it { is_expected.to include melborne_article, melborne_oregon_article }
+      it { is_expected.not_to include oregon_article }
+      it { expect(subject.to_sql).not_to include 'gutentag_tags' }
     end
 
     context 'given multiple tag objects' do
@@ -66,6 +76,7 @@ describe Gutentag::ActiveRecord do
 
       it { expect(subject.count).to eq 3 }
       it { is_expected.to include melborne_article, oregon_article, melborne_oregon_article }
+      it { expect(subject.to_sql).not_to include 'gutentag_tags' }
     end
 
     context 'chaining where clause' do


### PR DESCRIPTION
also adds support for tag_id as parameter

before:
```
SELECT DISTINCT "articles".* FROM "articles" 
INNER JOIN "gutentag_taggings" ON "gutentag_taggings"."taggable_id" = "articles"."id" AND "gutentag_taggings"."taggable_type" = 'Article' 
INNER JOIN "gutentag_tags" ON "gutentag_tags"."id" = "gutentag_taggings"."tag_id" WHERE "gutentag_tags"."name" IN ('melborne', 'oregon')
```

after less joining:
```
SELECT DISTINCT "articles".* FROM "articles" 
INNER JOIN "gutentag_taggings" ON "gutentag_taggings"."taggable_id" = "articles"."id" AND "gutentag_taggings"."taggable_type" = 'Article' WHERE "gutentag_taggings"."tag_id" IN (1, 2)
```