### PR TITLE
add string accessors for form submission

### DIFF
--- a/lib/gutentag/active_record.rb
+++ b/lib/gutentag/active_record.rb
@@ -4,6 +4,7 @@ module Gutentag::ActiveRecord
   extend ActiveSupport::Concern
 
   UNIQUENESS_METHOD = ActiveRecord::VERSION::MAJOR == 3 ? :uniq : :distinct
+  TAG_SEPARATOR = ",".freeze
 
   module ClassMethods
     def has_many_tags
@@ -34,6 +35,14 @@ module Gutentag::ActiveRecord
     Gutentag.dirtier.call self, names if Gutentag.dirtier
 
     @tag_names = names
+  end
+
+  def tags_as_string
+    tag_names.join(TAG_SEPARATOR)
+  end
+
+  def tags_as_string=(s)
+    self.tag_names = s.split(TAG_SEPARATOR)
   end
 
   private

--- a/spec/gutentag/active_record_spec.rb
+++ b/spec/gutentag/active_record_spec.rb
@@ -76,4 +76,32 @@ describe Gutentag::ActiveRecord do
       it { is_expected.not_to include oregon_article, melborne_oregon_article }
     end
   end
+
+  describe "#tags_as_string" do
+    let(:article) { Article.new }
+
+    it "is empty" do
+      expect(article.tags_as_string).to eq ""
+    end
+
+    it "shows tags" do
+      article.tag_names = ["foo", "bar"]
+      expect(article.tags_as_string).to eq "foo,bar"
+    end
+  end
+
+  describe "#tags_as_string=" do
+    let(:article) { Article.new }
+
+    it "can empty" do
+      article.tag_names = ["foo", "bar"]
+      article.tags_as_string = ""
+      expect(article.tag_names).to eq []
+    end
+
+    it "can assign" do
+      article.tags_as_string = "a,b,c"
+      expect(article.tag_names).to eq ["a", "b", "c"]
+    end
+  end
 end


### PR DESCRIPTION
makes it easy to convert a tet field into a tag accessor