### PR TITLE
Allow full customization of persist_tags callback

### DIFF
--- a/lib/gutentag/persistence.rb
+++ b/lib/gutentag/persistence.rb
@@ -13,6 +13,7 @@ class Gutentag::Persistence
     add_new
 
     taggable.reset_tag_names
+    self
   end
 
   private


### PR DESCRIPTION
[`Module#prepend`](http://ruby-doc.org/core-2.0.0/Module.html#method-i-prepend) (Ruby >= 2.0.0) can be used to:

1. *wrap* the `persist_tags` callback
2. call `super`
3. do something with the return value of the `super` call

Making the return value of `persist_tags` be the instance of `Gutentag::Persistence` will allow access to `@existing` and `@changes`, which in turn allows for powerful business logic built around tags.

*Example Model*
```
class Product < ActiveRecord::Base
  prepend UpdateStuffsOnTagging # wraps Gutentag::ActiveRecord#persist_tags
  Gutentag::ActiveRecord.call self
end
```

*Example Module*
```
module UpdateStuffsOnTagging
  def persist_tags
    gutentag_persistence = super
    # existing - new = tags that were removed
    if (removed_tags = gutentag_persistence.instance_variable_get(:@existing) - gutentag_persistence.instance_variable_get(:@changes))
      removed_tags.each do |tag_name|
        Resque.enqueue(DestroyStuffsOnTagRemoval, id, tag_name)
      end
    end
    # new - existing = tags that were added
    if (added_tags = gutentag_persistence.instance_variable_get(:@changes) - gutentag_persistence.instance_variable_get(:@existing))
      added_tags.each do |tag_name|
        Resque.enqueue(CreateStuffsOnTagAddition, id, tag_name)
      end
    end
    gutentag_persistence
  end
end
```

I didn't change the persistence class and expose the internals, because I appreciate the separation of concerns you have created.  Still, my example is ugly.

I am hackily accessing the internals of the persistence which is brittle, ugly, and barbarous.  An alternative then to returning `self` would be to return an object designed for the purpose of conveying information about the data changes back to the callback, like `PersistenceInfo` object that simply has data about the changes - before/after.