### PR TITLE
Validate tag name length according to the limit of the column

### DIFF
--- a/lib/gutentag/tag_validations.rb
+++ b/lib/gutentag/tag_validations.rb
@@ -13,6 +13,9 @@ class Gutentag::TagValidations
     klass.validates :name,
       :presence   => true,
       :uniqueness => {:case_sensitive => false}
+
+    limit = klass.columns_hash["name"].limit
+    klass.validates_length_of :name, :maximum => limit if limit
   end
 
   private

--- a/lib/gutentag/tag_validations.rb
+++ b/lib/gutentag/tag_validations.rb
@@ -15,7 +15,7 @@ class Gutentag::TagValidations
       :uniqueness => {:case_sensitive => false}
 
     limit = klass.columns_hash["name"].limit
-    klass.validates_length_of :name, :maximum => limit if limit
+    klass.validates_length_of :name, :maximum => limit if limit.present?
   end
 
   private

--- a/spec/models/gutentag/tag_spec.rb
+++ b/spec/models/gutentag/tag_spec.rb
@@ -64,35 +64,18 @@ describe Gutentag::Tag, :type => :model do
       expect(tag.errors[:name].length).to eq(1)
     end
 
-    context "length of name" do
+    if ENV["DATABASE"] == "mysql"
+      # When using MySQL, string columns convert to VARCHAR(255), therefore the
+      # column have a limit of 255, even though we did not specify a limit
       it "validates the length of the name" do
-        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Column).
-          to receive(:limit) { 255 }.
-          at_least(:once)
-
-        reload_gutentag_tag
-
-        tag = Gutentag::Tag.new(:name => "a" * 256)
-        tag.valid?
+        tag = Gutentag::Tag.create(:name => "a" * 256)
         expect(tag.errors[:name].length).to eq(1)
       end
-
+    else
       it "does not validate the length if the column has no limit" do
-        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Column).
-          to receive(:limit) { nil }.
-          at_least(:once)
-
-        reload_gutentag_tag
-
-        tag = Gutentag::Tag.new(:name => "a" * 256)
-        tag.valid?
+        tag = Gutentag::Tag.create(:name => "a" * 256)
         expect(tag.errors[:name].length).to eq(0)
       end
     end
   end
-end
-
-def reload_gutentag_tag
-  Gutentag.send(:remove_const, :Tag)
-  load "app/models/gutentag/tag.rb"
 end

--- a/spec/models/gutentag/tag_spec.rb
+++ b/spec/models/gutentag/tag_spec.rb
@@ -64,9 +64,12 @@ describe Gutentag::Tag, :type => :model do
       expect(tag.errors[:name].length).to eq(1)
     end
 
-    if ENV["DATABASE"] == "mysql"
-      # When using MySQL, string columns convert to VARCHAR(255), therefore the
-      # column have a limit of 255, even though we did not specify a limit
+    if ENV["DATABASE"] == "mysql" || (
+      Gem::Version.new(Rails.version) < Gem::Version.new("4.2.0")
+    )
+      # When using MySQL or Rails before 4.2, string columns convert to
+      # VARCHAR(255), therefore the column has a limit of 255, even though we
+      # did not specify a limit
       it "validates the length of the name" do
         tag = Gutentag::Tag.create(:name => "a" * 256)
         expect(tag.errors[:name].length).to eq(1)

--- a/spec/models/gutentag/tag_spec.rb
+++ b/spec/models/gutentag/tag_spec.rb
@@ -63,5 +63,36 @@ describe Gutentag::Tag, :type => :model do
       tag = Gutentag::Tag.create(:name => "Pancakes")
       expect(tag.errors[:name].length).to eq(1)
     end
+
+    context "length of name" do
+      it "validates the length of the name" do
+        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Column).
+          to receive(:limit) { 255 }.
+          at_least(:once)
+
+        reload_gutentag_tag
+
+        tag = Gutentag::Tag.new(:name => "a" * 256)
+        tag.valid?
+        expect(tag.errors[:name].length).to eq(1)
+      end
+
+      it "does not validate the length if the column has no limit" do
+        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Column).
+          to receive(:limit) { nil }.
+          at_least(:once)
+
+        reload_gutentag_tag
+
+        tag = Gutentag::Tag.new(:name => "a" * 256)
+        tag.valid?
+        expect(tag.errors[:name].length).to eq(0)
+      end
+    end
   end
+end
+
+def reload_gutentag_tag
+  Gutentag.send(:remove_const, :Tag)
+  load "app/models/gutentag/tag.rb"
 end


### PR DESCRIPTION
MySQL turns `string` into a `VARCHAR` with the limit of 255. With this,
we'll validate the length of the name attribute based on the limit.

Fixes #40 

The implement itself is rather straight forward: We just ask the column for it's limit and validate the length of the name according to the limit. 

However, testing this, since it happens on class/module level and not instance level, was ... interesting: I went deep down the 🐰 🕳  to reload the class in question and to make this possible.

The test is a bit ugly and combines a couple of techniques that I'm usually very careful with (stubbing & `any_instance`), but I think it makes sense to do that on class level and not by passing a lambda to the `maximum`, so it only happens once during the bootup of the app and not everytime you try to save a Gutentag::Tag.

Let me know what you think and maybe you have an idea to improve that. Open for discussions as usual.

Have a great day!