### PR TITLE
allow booting the host app without a database

### DIFF
--- a/lib/gutentag/tag_validations.rb
+++ b/lib/gutentag/tag_validations.rb
@@ -14,8 +14,10 @@ class Gutentag::TagValidations
       :presence   => true,
       :uniqueness => {:case_sensitive => false}
 
-    limit = klass.columns_hash["name"].limit
-    klass.validates_length_of :name, :maximum => limit if limit.present?
+    if klass.table_exist?
+      limit = klass.columns_hash["name"].limit
+      klass.validates_length_of :name, :maximum => limit if limit.present?
+    end
   end
 
   private


### PR DESCRIPTION
@pat 

`rake db:create test` fails with this atm since it tries to load the schema when booting rails :(

```
/home/travis/build/zendesk/cerebro/vendor/bundle/ruby/2.4.0/gems/mysql2-0.4.10/lib/mysql2/client.rb:120:in `_query': Mysql2::Error: Table 'cerebro_test.gutentag_tags' doesn't exist: SHOW FULL FIELDS FROM `gutentag_tags` (ActiveRecord::StatementInvalid)

	from /home/travis/build/zendesk/cerebro/vendor/bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/model_schema.rb:343:in `columns_hash'

	from /home/travis/build/zendesk/cerebro/vendor/bundle/ruby/2.4.0/gems/gutentag-1.1.0/lib/gutentag/tag_validations.rb:17:in `call'

	from /home/travis/build/zendesk/cerebro/vendor/bundle/ruby/2.4.0/gems/gutentag-1.1.0/lib/gutentag/tag_validations.rb:5:in `call'

	from /home/travis/build/zendesk/cerebro/vendor/bundle/ruby/2.4.0/gems/gutentag-1.1.0/app/models/gutentag/tag.rb:14:in `<class:Tag>'

	from /home/travis/build/zendesk/cerebro/vendor/bundle/ruby/2.4.0/gems/gutentag-1.1.0/app/models/gutentag/tag.rb:3:in `<top (required)>'
```