### PR TITLE
do not load models when not needed and make validations available wit…

### DIFF
--- a/app/models/gutentag/tag.rb
+++ b/app/models/gutentag/tag.rb
@@ -23,3 +23,6 @@ class Gutentag::Tag < ActiveRecord::Base
     super(Gutentag.normaliser.call(value))
   end
 end
+
+require "gutentag/tag_validations"
+Gutentag.tag_validations.call Gutentag::Tag

--- a/lib/gutentag.rb
+++ b/lib/gutentag.rb
@@ -38,13 +38,6 @@ require "gutentag/tagged_with"
 
 Gutentag.dirtier = Gutentag::Dirty if ActiveRecord::VERSION::STRING.to_f < 4.2
 
-require "active_support/lazy_load_hooks"
-ActiveSupport.on_load(:gutentag) do
-  require "gutentag/tag_validations"
-
-  Gutentag.tag_validations.call Gutentag::Tag
-end
-
 if defined?(Rails::Engine)
   require "gutentag/engine"
 else

--- a/lib/gutentag/engine.rb
+++ b/lib/gutentag/engine.rb
@@ -2,8 +2,4 @@
 
 class Gutentag::Engine < Rails::Engine
   engine_name :gutentag
-
-  config.after_initialize do
-    ActiveSupport.run_load_hooks :gutentag
-  end
 end


### PR DESCRIPTION
…hout rails

I have a verification in my app that makes sure no models are loaded when the app loads,
the new gutetag breaks it ... so let's fix it by being more lazy.

Now validations happen even after after_initialize so users can still override tag_validations and it will work when not using rails too.

@pat 
