### PR TITLE
Fix to Tag.names_for_scope

### DIFF
--- a/app/models/gutentag/tag.rb
+++ b/app/models/gutentag/tag.rb
@@ -21,8 +21,12 @@ class Gutentag::Tag < ActiveRecord::Base
 
   def self.names_for_scope(scope)
     join_conditions = {:taggable_type => scope.name}
-    if scope.current_scope.present?
-      join_conditions[:taggable_id] = scope.select(:id)
+    if scope.is_a?(ActiveRecord::Relation)
+      if scope.current_scope.present?
+        join_conditions[:taggable_id] = scope.select(:id)
+      else
+        return Gutentag::Tag.none
+      end
     end
 
     joins(:taggings).where(

--- a/spec/acceptance/tag_names_for_scope_spec.rb
+++ b/spec/acceptance/tag_names_for_scope_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe "Tag names for scopes" do
     expect(Gutentag::Tag.names_for_scope(Article)).
       to match_array(%w[ koala wombat cassowary ])
   end
+
+  it "returns an empty array for an empty scope" do
+    Article.create :title => "mammals", :tag_names => %w[ koala wombat ]
+    Article.create :title => "birds",   :tag_names => %w[ cassowary ]
+
+    expect(Gutentag::Tag.names_for_scope(Article.where(:title => "reptiles"))).
+      to match_array([])
+  end
 end


### PR DESCRIPTION
Handle the case where the scope is empty by returning
an empty array.

Fixes https://github.com/pat/gutentag/issues/72