### PR TITLE
Handle ConnectionNotEstablished when adding length validation

### DIFF
--- a/lib/gutentag/tag_validations.rb
+++ b/lib/gutentag/tag_validations.rb
@@ -13,6 +13,7 @@ class Gutentag::TagValidations
     if ActiveRecord::VERSION::STRING.to_f > 4.0
       classes << ActiveRecord::NoDatabaseError
     end
+    classes << ActiveRecord::ConnectionNotEstablished
     classes << Mysql2::Error     if defined?(::Mysql2)
     classes << PG::ConnectionBad if defined?(::PG)
     classes


### PR DESCRIPTION
While upgrading an app to Rails 6.1 It was failing with `ActiveRecord::ConnectionNotEstablished` error. It looks like it's being triggered by the validations here and Rails 6.1 changed some of the exceptions that are raised in [this patch](https://github.com/rails/rails/pull/40110/files#diff-538a9bf3450c3aed556a0d2eacc26839a60becd744cda8c0a247dcb06aa0f02fR45) 

It looks like this exception class has been around for [a long time](https://github.com/rails/rails/blame/d75c2a175215c0f6d011b60f1c9f2b6466184adb/activerecord/lib/active_record/errors.rb#L57) so I didn't put a version check around it.

I couldn't find any existing tests fo this and wasn't sure the best way to add one, if you could point me in the correct direction I would be happy to add some though.

Let me know if you need anything else!