### PR TITLE
Excluding tags query / match none option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ To return records that have _all_ specified tags, use `:match => :all`:
 Article.tagged_with(:ids => [tag_a.id, tag_b.id], :match => :all)
 ```
 
+To return records that have _none_ of the specified tags, use `:match => :none`:
+
+```ruby
+# Returns all articles that have *neither* tag_a nor tag_b.
+Article.tagged_with(:ids => [tag_a.id, tag_b.id], :match => :none)
+```
+
 <h2 id="installation">Installation</h2>
 
 ### Dependencies

--- a/lib/gutentag/tagged_with/query.rb
+++ b/lib/gutentag/tagged_with/query.rb
@@ -8,7 +8,7 @@ class Gutentag::TaggedWith::Query
   end
 
   def call
-    model.where "#{model_id} IN (#{query.to_sql})"
+    model.where "#{model_id} #{operator} (#{query.to_sql})"
   end
 
   private
@@ -20,8 +20,16 @@ class Gutentag::TaggedWith::Query
   end
 
   def query
-    return taggable_ids_query if match == :any || values.length == 1
+    return taggable_ids_query if match_any_or_none? || values.length == 1
 
     taggable_ids_query.having("COUNT(*) = #{values.length}").group(:taggable_id)
+  end
+
+  def operator
+    match == :none ? "NOT IN" : "IN"
+  end
+
+  def match_any_or_none?
+    %i[any none].include?(match)
   end
 end

--- a/spec/gutentag/active_record_spec.rb
+++ b/spec/gutentag/active_record_spec.rb
@@ -160,6 +160,26 @@ RSpec.describe Gutentag::ActiveRecord do
       it { is_expected.not_to include oregon_article }
     end
 
+    context "matching excluding one tag" do
+      subject do
+        Article.tagged_with(:names => %w[ melbourne ], :match => :none)
+      end
+
+      it { expect(subject.count).to eq 1 }
+      it { is_expected.to include oregon_article }
+      it do
+        is_expected.not_to include melbourne_oregon_article, melbourne_article
+      end
+    end
+
+    context "matching excluding all tags" do
+      subject do
+        Article.tagged_with(:names => %w[ melbourne oregon ], :match => :none)
+      end
+
+      it { expect(subject.count).to eq 0 }
+    end
+
     it "should work on STI subclasses" do
       thinkpiece = Thinkpiece.create! :tag_names => ["pancakes"]
 


### PR DESCRIPTION
Not sure if this is something that makes sense for the general public. Let me know if you are interested of merging this in and I can add some tests and update the `README.md` file.

I've added support for a `match: :none` option that would execute a `NOT IN` query.
