### PR TITLE
Tweak migrations to match current Rails version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 gemfiles
 pkg/*
 spec/internal/db/*.sqlite
+spec/internal/db/migrate/
 .rubocop-*-yml

--- a/README.md
+++ b/README.md
@@ -93,29 +93,11 @@ Get it into your Gemfile - and don't forget the version constraint!
 gem 'gutentag', '~> 2.5'
 ```
 
-Next: your tags get persisted to your database, so let's import the migrations:
+Next: your tags get persisted to your database, so let's import the migrations, update them to your current version of Rails, and then migrate:
 
 ```Bash
 bundle exec rake gutentag:install:migrations
-```
-
-**Before you run the migrations**: it is strongly recommended that you edit the superclass used in each of them to match your current Rails version. So, if you're using Rails v6.1, then use `ActiveRecord::Migration[6.1]` in each Gutentag migration file:
-
-```ruby
-# remove these lines:
-superclass = ActiveRecord::VERSION::MAJOR < 5 ?
-  ActiveRecord::Migration : ActiveRecord::Migration[4.2]
-
-# and alter the migration's superclass:
-class GutentagTables < ActiveRecord::Migration[6.1]
-# repeat for each Gutentag migration
-```
-
-It should be safe to use a superclass version anywhere between 4.2 and 6.1 - whatever your current version of Rails is recommended. If you're using Rails 4.2 or earlier, then your superclass _must_ be `ActiveRecord::Migration` with no version specified.
-
-Once these migration files have been edited accordingly, you can migrate your database:
-
-```Bash
+bundle exec rails generate gutentag:migration_versions
 bundle exec rake db:migrate
 ```
 

--- a/db/migrate/1_gutentag_tables.rb
+++ b/db/migrate/1_gutentag_tables.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-superclass = ActiveRecord::VERSION::MAJOR < 5 ?
-  ActiveRecord::Migration : ActiveRecord::Migration[4.2]
-class GutentagTables < superclass
+class GutentagTables < ActiveRecord::Migration
   def up
     create_table :gutentag_taggings do |t|
       t.integer :tag_id,        :null => false

--- a/db/migrate/2_gutentag_cache_counter.rb
+++ b/db/migrate/2_gutentag_cache_counter.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-superclass = ActiveRecord::VERSION::MAJOR < 5 ?
-  ActiveRecord::Migration : ActiveRecord::Migration[4.2]
-class GutentagCacheCounter < superclass
+class GutentagCacheCounter < ActiveRecord::Migration
   def up
     add_column :gutentag_tags, :taggings_count, :integer, :default => 0
     add_index  :gutentag_tags, :taggings_count

--- a/db/migrate/3_no_null_counters.rb
+++ b/db/migrate/3_no_null_counters.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-superclass = ActiveRecord::VERSION::MAJOR < 5 ?
-  ActiveRecord::Migration : ActiveRecord::Migration[4.2]
-class NoNullCounters < superclass
+class NoNullCounters < ActiveRecord::Migration
   def up
     change_column :gutentag_tags, :taggings_count, :integer,
       :default => 0,

--- a/lib/gutentag/engine.rb
+++ b/lib/gutentag/engine.rb
@@ -2,4 +2,8 @@
 
 class Gutentag::Engine < Rails::Engine
   engine_name :gutentag
+
+  generators do
+    require "gutentag/generators/migration_versions_generator"
+  end
 end

--- a/lib/gutentag/generators/migration_versions_generator.rb
+++ b/lib/gutentag/generators/migration_versions_generator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+
+module Gutentag
+  module Generators
+    class MigrationVersionsGenerator < Rails::Generators::Base
+      desc "Update the ActiveRecord version in Gutentag migrations"
+
+      def update_migration_versions
+        if ::ActiveRecord::VERSION::MAJOR < 5
+          puts "No changes required"
+        else
+          migration_files.each do |file|
+            gsub_file file,
+              /< ActiveRecord::Migration$/,
+              "< ActiveRecord::Migration[#{rails_version}]"
+          end
+        end
+      end
+
+      private
+
+      def migration_files
+        Dir[Rails.root.join("db/migrate/*.rb")].select do |path|
+          known_migration_names.any? do |known|
+            File.basename(path)[/\A\d+_#{known}\.gutentag.rb\z/]
+          end
+        end
+      end
+
+      def known_migration_names
+        @known_migration_names ||= begin
+          Dir[File.join(__dir__, "../../../db/migrate/*.rb")].collect do |path|
+            File.basename(path).gsub(/\A\d+_/, "").gsub(/\.rb\z/, "")
+          end
+        end
+      end
+
+      def rails_version
+        @rails_version ||= [
+          ::ActiveRecord::VERSION::MAJOR,
+          ::ActiveRecord::VERSION::MINOR
+        ].join(".")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,8 @@ Bundler.require :default, :development
 
 Dir["#{__dir__}/support/**/*.rb"].sort.each { |file| require file }
 
-Combustion.initialize! :active_record
+Combustion.initialize! :active_record, :database_migrate => false
+AdjustMigrations.call(Combustion::Application)
 ActiveSupport.run_load_hooks :gutentag unless defined?(Gutentag::Engine)
 
 require "rspec/rails"

--- a/spec/support/adjust_migrations.rb
+++ b/spec/support/adjust_migrations.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "gutentag/generators/migration_versions_generator"
+
+class AdjustMigrations
+  def self.call(application)
+    new(application).call
+  end
+
+  def initialize(application)
+    @application = application
+  end
+
+  def call
+    copy_migrations_to_app
+    run_generator
+    run_migrations
+  end
+
+  private
+
+  attr_reader :application
+
+  def copy_migrations_to_app
+    FileUtils.mkdir_p application.root.join("db/migrate")
+
+    Dir["#{__dir__}/../../db/migrate/*.rb"].each do |file|
+      name = File.basename(file.gsub(/rb\z/, "gutentag.rb"))
+      destination = application.root.join("db/migrate/#{name}")
+
+      FileUtils.cp file, destination.to_s
+    end
+  end
+
+  def migration_context
+    if ActiveRecord::MigrationContext.instance_method(:initialize).arity <= 1
+      ActiveRecord::MigrationContext.new migration_paths
+    else
+      ActiveRecord::MigrationContext.new(
+        migration_paths, ActiveRecord::Base.connection.schema_migration
+      )
+    end
+  end
+
+  def migration_paths
+    application.root.join("db/migrate")
+  end
+
+  def run_generator
+    Gutentag::Generators::MigrationVersionsGenerator.start(
+      ["--quiet"], :destination_root => application.root
+    )
+  end
+
+  def run_migrations
+    if ActiveRecord::VERSION::STRING.to_f >= 5.2
+      migration_context.migrate
+    else
+      ActiveRecord::Migrator.migrate migration_paths, nil
+    end
+  end
+end


### PR DESCRIPTION
As discussed in #80, the current approach to migrations in engines is flawed. So, instead of the clunky check in each migration, we can instead use a generator to update them to use the current Rails version at the time of the migrations being added. The test suite uses this approach too, so we can be sure that the migrations work in each Rails release. Essentially, this automates the recommendation in 04334272e41c55fb679c6aa03c5fc8eac0ec04cb.

It's not quite perfect - if new migrations get added to Gutentag, and someone's upgrading their app, the generator will be invoked on all Gutentag migrations (so, editing the old ones to use a potentially newer version of Rails). But at this point in time I'm not expecting further migrations - so, we can look into improving this if that changes.