### PR TITLE
Rails 8 compatibility

### DIFF
--- a/app/models/gutentag/tag.rb
+++ b/app/models/gutentag/tag.rb
@@ -33,7 +33,7 @@ class Gutentag::Tag < ActiveRecord::Base
   end
 
   def name=(value)
-    super(Gutentag.normaliser.call(value))
+    write_attribute(:name, Gutentag.normaliser.call(value))
   end
 end
 


### PR DESCRIPTION
When using `super` there are circumstances (that I haven't understood fully) where you end up with the following error:

```
NoMethodError:
  super: no superclass method `name=' for an instance of Gutentag::Tag
```

Using `write_attribute` instead seems to help.

See https://github.com/ujh/fountainpencompanion/actions/runs/11775441321/job/32795894190 for failing tests and then https://github.com/ujh/fountainpencompanion/actions/runs/11780359201/job/32810787231 for the tests passing with this change.